### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: / /service/api
+    schedule:
+      interval: weekly
+


### PR DESCRIPTION
Adds .github/dependabot.yml so dependabot tracks Go module updates on this repo. One entry per go.mod directory. Matches the standard config used in quark, gateway, telemetry, and other ZenRows Go services.